### PR TITLE
Return explicit false if match returns nil

### DIFF
--- a/lib/platform_agent.rb
+++ b/lib/platform_agent.rb
@@ -110,7 +110,7 @@ class PlatformAgent
     attr_accessor :user_agent_string
 
     def match?(pattern)
-      true if user_agent_string.to_s.match(pattern)
+      !!user_agent_string.to_s.match(pattern)
     end
 
     def user_agent


### PR DESCRIPTION
Not necessary at all but a common best practice instead of relying on truthy or falsy values 😄 

http://pragmati.st/2012/03/24/the-elements-of-ruby-style-predicate-methods/