### PR TITLE
Add OS to the list of delegated methods

### DIFF
--- a/lib/platform_agent.rb
+++ b/lib/platform_agent.rb
@@ -5,7 +5,7 @@ class PlatformAgent
     self.user_agent_string = user_agent_string
   end
 
-  delegate :browser, :version, :product, to: :user_agent
+  delegate :browser, :version, :product, :os, to: :user_agent
 
   def desktop?
     !mobile?

--- a/lib/platform_agent.rb
+++ b/lib/platform_agent.rb
@@ -89,7 +89,7 @@ class PlatformAgent
 
   def app_version
     # App user-agent string is parsed into two separate UserAgent instances, it's the last one that contains the right version
-    user_agent.last.version if native?
+    user_agent.last.version if native_app?
   end
 
   def to_s


### PR DESCRIPTION
This might not be as useful for selecting a different UI, but can be quite useful when using the User Agent to show information about a particular device being used. 

This pull request also fixes a small typo in the `app_version` method. 